### PR TITLE
Translate UI to English

### DIFF
--- a/forms/darbuotojai.py
+++ b/forms/darbuotojai.py
@@ -2,20 +2,20 @@ import streamlit as st
 
 def darbuotojas_form():
     """
-    Formos komponentas naujam darbuotojui.
-    Grąžina duomenis kaip žodyną arba None, jei nepateikta.
+    Form component for a new employee.
+    Returns data as a dict or None if not provided.
     """
     with st.form("darbuotojas_form", clear_on_submit=True):
-        vardas = st.text_input("Vardas")
-        pavarde = st.text_input("Pavardė")
-        pareigybe = st.text_input("Pareigybė")
-        el_pastas = st.text_input("El. paštas")
-        telefonas = st.text_input("Telefonas")
-        grupe = st.text_input("Grupė")
-        submitted = st.form_submit_button("💾 Išsaugoti darbuotoją")
+        vardas = st.text_input("First name")
+        pavarde = st.text_input("Last name")
+        pareigybe = st.text_input("Position")
+        el_pastas = st.text_input("Email")
+        telefonas = st.text_input("Phone")
+        grupe = st.text_input("Group")
+        submitted = st.form_submit_button("💾 Save employee")
         if submitted:
             if not vardas or not pavarde:
-                st.error("Vardas ir pavardė yra privalomi.")
+                st.error("First and last name are required.")
                 return None
             return {
                 "vardas": vardas.strip(),
@@ -26,3 +26,5 @@ def darbuotojas_form():
                 "grupe": grupe.strip(),
             }
     return None
+
+render_form = darbuotojas_form

--- a/forms/grupes.py
+++ b/forms/grupes.py
@@ -2,17 +2,17 @@ import streamlit as st
 
 def grupe_form():
     """
-    Formos komponentas naujos grupės kūrimui.
-    Grąžina duomenis kaip žodyną arba None, jei nepateikta.
+    Form component for creating a new group.
+    Returns a dict or None if not provided.
     """
     with st.form("grupe_form", clear_on_submit=True):
-        numeris = st.text_input("Grupės numeris")
-        pavadinimas = st.text_input("Pavadinimas")
-        aprasymas = st.text_area("Aprašymas")
-        submitted = st.form_submit_button("💾 Išsaugoti grupę")
+        numeris = st.text_input("Group number")
+        pavadinimas = st.text_input("Name")
+        aprasymas = st.text_area("Description")
+        submitted = st.form_submit_button("💾 Save group")
         if submitted:
             if not numeris or not pavadinimas:
-                st.error("Numeris ir pavadinimas yra privalomi.")
+                st.error("Number and name are required.")
                 return None
             return {
                 "numeris": numeris.strip(),
@@ -20,3 +20,5 @@ def grupe_form():
                 "aprasymas": aprasymas.strip()
             }
     return None
+
+render_form = grupe_form

--- a/forms/klientai.py
+++ b/forms/klientai.py
@@ -3,19 +3,19 @@ import streamlit as st
 from typing import Dict, Any
 
 def klientai_form() -> Dict[str, Any] | None:
-    st.subheader("📋 Klientų valdymas")
+    st.subheader("📋 Client management")
     with st.form("klientai_form", clear_on_submit=False):
-        pavadinimas = st.text_input("Įmonės pavadinimas")
-        kontaktai = st.text_input("Kontaktai")
-        salis = st.text_input("Šalis")
-        miestas = st.text_input("Miestas")
-        regionas = st.text_input("Regionas")
-        vat_numeris = st.text_input("PVM numeris")
+        pavadinimas = st.text_input("Company name")
+        kontaktai = st.text_input("Contacts")
+        salis = st.text_input("Country")
+        miestas = st.text_input("City")
+        regionas = st.text_input("Region")
+        vat_numeris = st.text_input("VAT number")
 
-        submitted = st.form_submit_button("💾 Išsaugoti klientą")
+        submitted = st.form_submit_button("💾 Save client")
         if submitted:
             if not pavadinimas:
-                st.error("❌ Įmonės pavadinimas būtinas.")
+                st.error("❌ Company name is required.")
                 return None
             return {
                 "pavadinimas": pavadinimas,
@@ -26,3 +26,5 @@ def klientai_form() -> Dict[str, Any] | None:
                 "vat_numeris": vat_numeris
             }
     return None
+
+render_form = klientai_form

--- a/forms/kroviniai.py
+++ b/forms/kroviniai.py
@@ -6,45 +6,45 @@ from typing import Dict, Any
 
 
 def krovinio_form() -> Dict[str, Any] | None:
-    st.subheader("📋 Krovinių valdymas")
+    st.subheader("📋 Cargo management")
     with st.form("krovinys_form", clear_on_submit=False):
-        klientas = st.text_input("Klientas")
-        uzsakymo_numeris = st.text_input("Užsakymo numeris")
-        pakrovimo_numeris = st.text_input("Pakrovimo numeris")
+        klientas = st.text_input("Client")
+        uzsakymo_numeris = st.text_input("Order number")
+        pakrovimo_numeris = st.text_input("Loading number")
         col1, col2 = st.columns(2)
-        pakrovimo_data = col1.date_input("Pakrovimo data", date.today())
-        pakrovimo_laikas_nuo = col1.time_input("Laikas nuo (pakrovimas)", time(8, 0))
-        pakrovimo_laikas_iki = col1.time_input("Laikas iki (pakrovimas)", time(17, 0))
-        iskrovimo_data = col2.date_input("Iškrovimo data", pakrovimo_data)
-        iskrovimo_laikas_nuo = col2.time_input("Laikas nuo (iškrovimas)", time(8, 0))
-        iskrovimo_laikas_iki = col2.time_input("Laikas iki (iškrovimas)", time(17, 0))
+        pakrovimo_data = col1.date_input("Loading date", date.today())
+        pakrovimo_laikas_nuo = col1.time_input("Time from (loading)", time(8, 0))
+        pakrovimo_laikas_iki = col1.time_input("Time to (loading)", time(17, 0))
+        iskrovimo_data = col2.date_input("Unloading date", pakrovimo_data)
+        iskrovimo_laikas_nuo = col2.time_input("Time from (unloading)", time(8, 0))
+        iskrovimo_laikas_iki = col2.time_input("Time to (unloading)", time(17, 0))
 
-        pakrovimo_salis = st.text_input("Pakrovimo šalis")
-        pakrovimo_miestas = st.text_input("Pakrovimo miestas")
-        iskrovimo_salis = st.text_input("Iškrovimo šalis")
-        iskrovimo_miestas = st.text_input("Iškrovimo miestas")
+        pakrovimo_salis = st.text_input("Loading country")
+        pakrovimo_miestas = st.text_input("Loading city")
+        iskrovimo_salis = st.text_input("Unloading country")
+        iskrovimo_miestas = st.text_input("Unloading city")
 
-        vilkikas = st.text_input("Vilkikas")
-        priekaba = st.text_input("Priekaba")
-        atsakingas_vadybininkas = st.text_input("Atsakingas vadybininkas")
+        vilkikas = st.text_input("Truck")
+        priekaba = st.text_input("Trailer")
+        atsakingas_vadybininkas = st.text_input("Responsible manager")
 
-        kilometrai = st.number_input("Kilometrai", min_value=0, value=0)
-        frachtas = st.number_input("Frachtas (€)", min_value=0.0, value=0.0)
-        svoris = st.number_input("Svoris (kg)", min_value=0, value=0)
-        paleciu_skaicius = st.number_input("Padėklų skaičius", min_value=0, value=0)
+        kilometrai = st.number_input("Kilometers", min_value=0, value=0)
+        frachtas = st.number_input("Freight (€)", min_value=0.0, value=0.0)
+        svoris = st.number_input("Weight (kg)", min_value=0, value=0)
+        paleciu_skaicius = st.number_input("Number of pallets", min_value=0, value=0)
 
         busena = st.selectbox(
-            "Būsena", ["suplanuotas", "pakrautas", "iškrautas"]
+            "Status", ["planned", "loaded", "unloaded"]
         )
 
-        submitted = st.form_submit_button("💾 Išsaugoti krovinį")
+        submitted = st.form_submit_button("💾 Save cargo")
         if submitted:
             # Validacija
             if not klientas or not uzsakymo_numeris:
-                st.error("❌ Privalomi laukai: Klientas ir Užsakymo numeris.")
+                st.error("❌ Required fields: Client and Order number.")
                 return None
             if pakrovimo_data > iskrovimo_data:
-                st.error("❌ Pakrovimo data negali būti vėlesnė už iškrovimo datą.")
+                st.error("❌ Loading date cannot be later than unloading date.")
                 return None
 
             return {
@@ -71,3 +71,5 @@ def krovinio_form() -> Dict[str, Any] | None:
                 "busena": busena
             }
     return None
+
+render_form = krovinio_form

--- a/forms/nustatymai.py
+++ b/forms/nustatymai.py
@@ -1,17 +1,19 @@
 import streamlit as st
 
 def nustatymai_form(kategorijos):
-    st.subheader("Pridėti naują reikšmę")
-    kat = st.selectbox("Kategorija", kategorijos)
-    val = st.text_input("Reikšmė")
-    if st.button("➕ Pridėti"):
+    st.subheader("Add new value")
+    kat = st.selectbox("Category", kategorijos)
+    val = st.text_input("Value")
+    if st.button("➕ Add"):
         if kat and val:
             return kat, val.strip()
     st.markdown("---")
-    st.subheader("Ištrinti reikšmę")
-    kat2 = st.selectbox("Kategorija (ištrinti)", [""] + kategorijos, key="del_cat")
-    val2 = st.selectbox("Reikšmė (ištrinti)", [""] + (get_values_placeholder(kat2) if kat2 else []), key="del_val")
-    if st.button("🗑️ Ištrinti"):
+    st.subheader("Delete value")
+    kat2 = st.selectbox("Category (delete)", ["" ] + kategorijos, key="del_cat")
+    val2 = st.selectbox("Value (delete)", ["" ] + (get_values_placeholder(kat2) if kat2 else []), key="del_val")
+    if st.button("🗑️ Delete"):
         if kat2 and val2:
             return kat2, val2
     return None
+
+render_form = nustatymai_form

--- a/forms/priekabos.py
+++ b/forms/priekabos.py
@@ -2,15 +2,15 @@ import streamlit as st
 
 def priekaba_form():
     with st.form("priekaba_form", clear_on_submit=True):
-        tipas = st.text_input("Priekabų tipas")
-        numeris = st.text_input("Valstybinis numeris")
-        marke = st.text_input("Markė")
-        pagaminimo_metai = st.text_input("Pagaminimo metai")
-        tech_apziura = st.date_input("Tech. apžiūra")
-        submitted = st.form_submit_button("💾 Išsaugoti priekabą")
+        tipas = st.text_input("Trailer type")
+        numeris = st.text_input("License plate")
+        marke = st.text_input("Make")
+        pagaminimo_metai = st.text_input("Manufacture year")
+        tech_apziura = st.date_input("Inspection")
+        submitted = st.form_submit_button("💾 Save trailer")
         if submitted:
             if not numeris:
-                st.error("Numeris yra privalomas.")
+                st.error("Number is required.")
                 return None
             return {
                 "priekabu_tipas": tipas.strip(),
@@ -20,3 +20,5 @@ def priekaba_form():
                 "tech_apziura": str(tech_apziura)
             }
     return None
+
+render_form = priekaba_form

--- a/forms/vairuotojai.py
+++ b/forms/vairuotojai.py
@@ -2,19 +2,19 @@ import streamlit as st
 
 def vairuotojas_form():
     """
-    Formos komponentas naujam vairuotojui.
-    Grąžina duomenis kaip žodyną arba None, jei nepateikta.
+    Form component for a new driver.
+    Returns a dict or None if not provided.
     """
     with st.form("vairuotojas_form", clear_on_submit=True):
-        vardas = st.text_input("Vardas")
-        pavarde = st.text_input("Pavardė")
-        gimimo_metai = st.text_input("Gimimo metai")
-        tautybe = st.text_input("Tautybė")
-        priskirtas_vilkikas = st.text_input("Priskirtas vilkikas")
-        submitted = st.form_submit_button("💾 Išsaugoti vairuotoją")
+        vardas = st.text_input("First name")
+        pavarde = st.text_input("Last name")
+        gimimo_metai = st.text_input("Birth year")
+        tautybe = st.text_input("Nationality")
+        priskirtas_vilkikas = st.text_input("Assigned truck")
+        submitted = st.form_submit_button("💾 Save driver")
         if submitted:
             if not vardas or not pavarde:
-                st.error("Vardas ir pavardė yra privalomi.")
+                st.error("First and last name are required.")
                 return None
             return {
                 "vardas": vardas.strip(),
@@ -24,3 +24,5 @@ def vairuotojas_form():
                 "priskirtas_vilkikas": priskirtas_vilkikas.strip(),
             }
     return None
+
+render_form = vairuotojas_form

--- a/forms/vilkikai.py
+++ b/forms/vilkikai.py
@@ -2,21 +2,21 @@ import streamlit as st
 
 def vilkikas_form():
     """
-    Formos komponentas naujam vilkikui.
-    Grąžina dict arba None.
+    Form component for a new truck.
+    Returns a dict or None.
     """
     with st.form("vilkikas_form", clear_on_submit=True):
-        numeris = st.text_input("Numeris")
-        marke = st.text_input("Markė")
-        pagaminimo_metai = st.text_input("Pagaminimo metai")
-        tech_apziura = st.date_input("Tech. apžiūra")
-        vadybininkas = st.text_input("Vadybininkas")
-        vairuotojai = st.text_input("Vairuotojai (kableliais)")
-        priekaba = st.selectbox("Priekaba", [""] + get_priekabu_sarasas())
-        submitted = st.form_submit_button("💾 Išsaugoti vilkiką")
+        numeris = st.text_input("Number")
+        marke = st.text_input("Make")
+        pagaminimo_metai = st.text_input("Manufacture year")
+        tech_apziura = st.date_input("Inspection")
+        vadybininkas = st.text_input("Manager")
+        vairuotojai = st.text_input("Drivers (comma separated)")
+        priekaba = st.selectbox("Trailer", ["" ] + get_priekabu_sarasas())
+        submitted = st.form_submit_button("💾 Save truck")
         if submitted:
             if not numeris:
-                st.error("Numeris yra privalomas.")
+                st.error("Number is required.")
                 return None
             return {
                 "numeris": numeris.strip(),
@@ -28,3 +28,5 @@ def vilkikas_form():
                 "priekaba": priekaba.strip()
             }
     return None
+
+render_form = vilkikas_form

--- a/main.py
+++ b/main.py
@@ -11,20 +11,20 @@ from modules.grupes        import show as show_grupes
 from modules.nustatymai    import show as show_nustatymai
 
 st.set_page_config(layout="wide")
-conn = init_db()
+conn, c = init_db()
 
 PAGES = {
-    "Vilkikai":    show_vilkikai,
-    "Priekabos":    show_priekabos,
-    "Kroviniai":    show_kroviniai,
-    "Darbuotojai":  show_darbuotojai,
-    "Klientai":     show_klientai,
-    "Grupės":       show_grupes,
-    "Nustatymai":   show_nustatymai
+    "Trucks":       show_vilkikai,
+    "Trailers":     show_priekabos,
+    "Cargo":        show_kroviniai,
+    "Employees":    show_darbuotojai,
+    "Clients":      show_klientai,
+    "Groups":       show_grupes,
+    "Settings":     show_nustatymai
 }
 
-st.sidebar.title("DISPO moduliai")
-page = st.sidebar.radio("Pasirink modulį", list(PAGES.keys()))
+st.sidebar.title("DISPO modules")
+page = st.sidebar.radio("Select module", list(PAGES.keys()))
 
-# Kviečiame tik conn argumentą
-PAGES[page](conn)
+# Call selected page
+PAGES[page](conn, c)

--- a/modules/darbuotojai.py
+++ b/modules/darbuotojai.py
@@ -1,18 +1,18 @@
 import streamlit as st
 import pandas as pd
 
-from forms.darbuotojai import render_form as darbuotojai_form
+from forms.darbuotojai import darbuotojas_form as darbuotojai_form
 from logic.darbuotojai import get_all_darbuotojai, insert_darbuotojas, update_grupe
-from tables.darbuotojai import render_table as darbuotojai_table
+from table.darbuotojai import show_darbuotojai_table as darbuotojai_table
 
 def show(conn, c):
-    st.title("DISPO – Darbuotojai")
+    st.title("DISPO – Employees")
 
-    with st.expander("➕ Pridėti naują darbuotoją", expanded=True):
+    with st.expander("➕ Add new employee", expanded=True):
         data = darbuotojai_form(conn, c)
-        if data and st.button("💾 Išsaugoti darbuotoją"):
+        if data and st.button("💾 Save employee"):
             insert_darbuotojas(conn, c, data)
-            st.success("✅ Darbuotoją išsaugojau")
+            st.success("✅ Employee saved")
 
     df = pd.DataFrame(
         get_all_darbuotojai(conn, c),
@@ -24,4 +24,4 @@ def show(conn, c):
     if edited is not None:
         for row in edited.to_dict(orient="records"):
             update_grupe(conn, c, row["id"], row["grupe"])
-        st.success("✅ Atnaujinau grupes")
+        st.success("✅ Groups updated")

--- a/modules/grupes.py
+++ b/modules/grupes.py
@@ -1,18 +1,18 @@
 import streamlit as st
 import pandas as pd
 
-from forms.grupes import render_form as grupes_form
+from forms.grupes import grupe_form as grupes_form
 from logic.grupes import get_all_grupes, insert_grupe, update_aprasymas
-from tables.grupes import render_table as grupes_table
+from table.grupes import show_grupes_table as grupes_table
 
 def show(conn, c):
-    st.title("DISPO – Grupės")
+    st.title("DISPO – Groups")
 
-    with st.expander("➕ Pridėti naują grupę", expanded=True):
+    with st.expander("➕ Add new group", expanded=True):
         data = grupes_form(conn, c)
-        if data and st.button("💾 Išsaugoti grupę"):
+        if data and st.button("💾 Save group"):
             insert_grupe(conn, c, data)
-            st.success("✅ Grupę išsaugojau")
+            st.success("✅ Group saved")
 
     df = pd.DataFrame(
         get_all_grupes(conn, c),
@@ -23,4 +23,4 @@ def show(conn, c):
     if edited is not None:
         for row in edited.to_dict(orient="records"):
             update_aprasymas(conn, c, row["id"], row["aprasymas"])
-        st.success("✅ Atnaujinau aprašymus")
+        st.success("✅ Descriptions updated")

--- a/modules/klientai.py
+++ b/modules/klientai.py
@@ -1,18 +1,18 @@
 import streamlit as st
 import pandas as pd
 
-from forms.klientai import render_form as klientai_form
+from forms.klientai import klientai_form as klientai_form
 from logic.klientai import get_all_klientai, insert_klientas, update_regionas
-from tables.klientai import render_table as klientai_table
+from table.klientai import show_klientai_table as klientai_table
 
 def show(conn, c):
-    st.title("DISPO – Klientai")
+    st.title("DISPO – Clients")
 
-    with st.expander("➕ Pridėti naują klientą", expanded=True):
+    with st.expander("➕ Add new client", expanded=True):
         data = klientai_form(conn, c)
-        if data and st.button("💾 Išsaugoti klientą"):
+        if data and st.button("💾 Save client"):
             insert_klientas(conn, c, data)
-            st.success("✅ Klientą išsaugojau")
+            st.success("✅ Client saved")
 
     df = pd.DataFrame(
         get_all_klientai(conn, c),
@@ -24,4 +24,4 @@ def show(conn, c):
     if edited is not None:
         for row in edited.to_dict(orient="records"):
             update_regionas(conn, c, row["id"], row["regionas"])
-        st.success("✅ Atnaujinau regionus")
+        st.success("✅ Regions updated")

--- a/modules/kroviniai.py
+++ b/modules/kroviniai.py
@@ -1,18 +1,18 @@
 import streamlit as st
 import pandas as pd
 
-from forms.kroviniai import render_form as kroviniai_form
+from forms.kroviniai import krovinio_form as kroviniai_form
 from logic.kroviniai import get_all_kroviniai, insert_krovinys, update_busena
-from tables.kroviniai import render_table as kroviniai_table
+from table.kroviniai import show_kroviniai_table as kroviniai_table
 
 def show(conn, c):
-    st.title("DISPO – Krovinių valdymas")
+    st.title("DISPO – Cargo Management")
 
-    with st.expander("➕ Pridėti naują krovinį", expanded=True):
+    with st.expander("➕ Add new cargo", expanded=True):
         data = kroviniai_form(conn, c)
-        if data and st.button("💾 Išsaugoti krovinį"):
+        if data and st.button("💾 Save cargo"):
             insert_krovinys(conn, c, data)
-            st.success("✅ Krovinį išsaugojau")
+            st.success("✅ Cargo saved")
 
     df = pd.DataFrame(
         get_all_kroviniai(conn, c),
@@ -31,4 +31,4 @@ def show(conn, c):
     if edited is not None:
         for row in edited.to_dict(orient="records"):
             update_busena(conn, c, row["id"], row["busena"])
-        st.success("✅ Atnaujinau būsenas")
+        st.success("✅ Statuses updated")

--- a/modules/nustatymai.py
+++ b/modules/nustatymai.py
@@ -1,37 +1,37 @@
 import streamlit as st
 
-from forms.nustatymai import render_form as nustatymai_form
+from forms.nustatymai import nustatymai_form as nustatymai_form
 from logic.nustatymai import get_all_categories, insert_lookup, delete_lookup
 
 def show(conn, c):
-    st.title("DISPO – Nustatymai (lookup)")
+    st.title("DISPO – Settings (lookup)")
 
-    # 1. Įvesti / pasirinkti kategoriją
+    # 1. Enter or select category
     cats = get_all_categories(conn, c)
     col1, col2 = st.columns(2)
-    selected = col1.selectbox("Esama kategorija", [""] + cats)
-    new_cat = col2.text_input("Arba nauja kategorija")
+    selected = col1.selectbox("Existing category", ["" ] + cats)
+    new_cat = col2.text_input("Or new category")
     kat = new_cat.strip() or selected
 
     if kat:
-        st.subheader(f"Kategorija: **{kat}**")
-        # 2. Rodyti esamas reikšmes
+        st.subheader(f"Category: **{kat}**")
+        # 2. Show existing values
         values = [v for v in c.execute(
             "SELECT reiksme FROM lookup WHERE kategorija=?", (kat,)
         ).fetchall()]
-        st.write([v[0] for v in values] or "_(nerasta)_")
+        st.write([v[0] for v in values] or "_(not found)_")
 
         # 3. Pridėti reikšmę
-        rv = st.text_input("Nauja reikšmė")
-        if st.button("➕ Pridėti"):
+        rv = st.text_input("New value")
+        if st.button("➕ Add"):
             insert_lookup(conn, c, kat, rv)
             st.experimental_rerun()
 
         # 4. Ištrinti reikšmę
-        delv = st.selectbox("Ištrinti", [""] + [v[0] for v in values])
-        if st.button("🗑 Pašalinti"):
+        delv = st.selectbox("Delete", ["" ] + [v[0] for v in values])
+        if st.button("🗑 Remove"):
             delete_lookup(conn, c, kat, delv)
             st.experimental_rerun()
 
     else:
-        st.info("Pasirink arba įvesk kategoriją aukščiau.")
+        st.info("Select or enter a category above.")

--- a/modules/priekabos.py
+++ b/modules/priekabos.py
@@ -1,21 +1,21 @@
 import streamlit as st
 import pandas as pd
 
-from forms.priekabos import render_form as priekabos_form
+from forms.priekabos import priekaba_form as priekabos_form
 from logic.priekabos import get_all_priekabos, insert_priekaba, update_priskirta
-from tables.priekabos import render_table as priekabos_table
+from table.priekabos import show_priekabos_table as priekabos_table
 
 def show(conn, c):
-    st.title("DISPO – Priekabų valdymas")
+    st.title("DISPO – Trailer Management")
 
-    # 1. Įvedimo forma
-    with st.expander("➕ Pridėti naują priekabą", expanded=True):
+    # 1. Input form
+    with st.expander("➕ Add new trailer", expanded=True):
         data = priekabos_form(conn, c)
-        if data and st.button("💾 Išsaugoti priekabą"):
+        if data and st.button("💾 Save trailer"):
             insert_priekaba(conn, c, data)
-            st.success("✅ Priekabą išsaugojau")
+            st.success("✅ Trailer saved")
 
-    # 2. Lentelė
+    # 2. Table
     df = pd.DataFrame(
         get_all_priekabos(conn, c),
         columns=["id", "tipas", "numeris", "marke",
@@ -23,8 +23,8 @@ def show(conn, c):
     )
     edited = priekabos_table(df, key="priekabos")
 
-    # 3. Atnaujinti priskirtą vilkiką
+    # 3. Update assigned truck
     if edited is not None:
         for row in edited.to_dict(orient="records"):
             update_priskirta(conn, c, row["id"], row["priskirtas_vilkikas"])
-        st.success("✅ Atnaujinau priskyrimus")
+        st.success("✅ Assignments updated")

--- a/modules/vairuotojai.py
+++ b/modules/vairuotojai.py
@@ -1,18 +1,18 @@
 import streamlit as st
 import pandas as pd
 
-from forms.vairuotojai import render_form as vairuotojai_form
+from forms.vairuotojai import vairuotojas_form as vairuotojai_form
 from logic.vairuotojai import get_all_vairuotojai, insert_vairuotojas, update_vilkikas
-from tables.vairuotojai import render_table as vairuotojai_table
+from table.vairuotojai import show_vairuotojai_table as vairuotojai_table
 
 def show(conn, c):
-    st.title("DISPO – Vairuotojai")
+    st.title("DISPO – Drivers")
 
-    with st.expander("➕ Pridėti naują vairuotoją", expanded=True):
+    with st.expander("➕ Add new driver", expanded=True):
         data = vairuotojai_form(conn, c)
-        if data and st.button("💾 Išsaugoti vairuotoją"):
+        if data and st.button("💾 Save driver"):
             insert_vairuotojas(conn, c, data)
-            st.success("✅ Vairuotoją išsaugojau")
+            st.success("✅ Driver saved")
 
     df = pd.DataFrame(
         get_all_vairuotojai(conn, c),
@@ -24,4 +24,4 @@ def show(conn, c):
     if edited is not None:
         for row in edited.to_dict(orient="records"):
             update_vilkikas(conn, c, row["id"], row["priskirtas_vilkikas"])
-        st.success("✅ Atnaujinau priskyrimus")
+        st.success("✅ Assignments updated")

--- a/modules/vilkikai.py
+++ b/modules/vilkikai.py
@@ -1,21 +1,21 @@
 import streamlit as st
 import pandas as pd
 
-from forms.vilkikai import render_form as vilkikai_form
+from forms.vilkikai import vilkikas_form as vilkikai_form
 from logic.vilkikai import get_all_vilkikai, insert_vilkikas, update_priekaba
-from tables.vilkikai import render_table as vilkikai_table
+from table.vilkikai import show_vilkikai_table as vilkikai_table
 
 def show(conn, c):
-    st.title("DISPO – Vilkikų valdymas")
+    st.title("DISPO – Truck Management")
 
-    # 1. Įvedimo forma
-    with st.expander("➕ Pridėti naują vilkiką", expanded=True):
+    # 1. Input form
+    with st.expander("➕ Add new truck", expanded=True):
         data = vilkikai_form(conn, c)
-        if data and st.button("💾 Išsaugoti vilkiką"):
+        if data and st.button("💾 Save truck"):
             insert_vilkikas(conn, c, data)
-            st.success("✅ Vilkiką išsaugojau")
+            st.success("✅ Truck saved")
 
-    # 2. Duomenų atvaizdavimas
+    # 2. Display data
     df = pd.DataFrame(
         get_all_vilkikai(conn, c),
         columns=["id", "numeris", "marke", "pagaminimo_metai",
@@ -23,8 +23,8 @@ def show(conn, c):
     )
     edited = vilkikai_table(df, key="vilkikai")
 
-    # 3. Atnaujinti priekabą, jei redagavo lenteleje
+    # 3. Update trailer if edited in table
     if edited is not None:
         for row in edited.to_dict(orient="records"):
             update_priekaba(conn, c, row["id"], row["priekaba"])
-        st.success("✅ Atnaujinau priekabas")
+        st.success("✅ Updated trailers")

--- a/table/darbuotojai.py
+++ b/table/darbuotojai.py
@@ -4,11 +4,11 @@ from typing import List, Dict, Any
 
 def show_darbuotojai_table(rows: List[Dict[str, Any]]) -> pd.DataFrame:
     """
-    Rodo darbuotojų lentelę su galimybe redaguoti įrašus.
-    Grąžina redaguotą DataFrame, kad būtų galima apdoroti pakeitimus.
+    Display employees table with edit options.
+    Returns the edited DataFrame for processing.
     """
     if not rows:
-        st.info("ℹ️ Nėra darbuotojų įrašų.")
+        st.info("ℹ️ No employee records.")
         return pd.DataFrame()
 
     df = pd.DataFrame(rows)

--- a/table/grupes.py
+++ b/table/grupes.py
@@ -4,12 +4,11 @@ from typing import List, Dict, Any
 
 def show_grupes_table(rows: List[Dict[str, Any]]) -> pd.DataFrame:
     """
-    Rodo grupių lentelę su galimybe redaguoti:
-    numerį, pavadinimą, aprašymą.
-    Grąžina redaguotą DataFrame.
+    Display groups table with editable number, name and description.
+    Returns the edited DataFrame.
     """
     if not rows:
-        st.info("ℹ️ Nėra sukurtų grupių.")
+        st.info("ℹ️ No groups created.")
         return pd.DataFrame()
 
     df = pd.DataFrame(rows)

--- a/table/klientai.py
+++ b/table/klientai.py
@@ -4,11 +4,11 @@ from typing import List, Dict, Any
 
 def show_klientai_table(rows: List[Dict[str, Any]]) -> pd.DataFrame:
     """
-    Rodo klientų lentelę su galimybe peržiūrėti ir redaguoti.
-    Grąžina redaguotą DataFrame, kad būtų galima apdoroti pakeitimus.
+    Display clients table with edit capability.
+    Returns the edited DataFrame for processing.
     """
     if not rows:
-        st.info("ℹ️ Nėra klientų įrašų.")
+        st.info("ℹ️ No client records.")
         return pd.DataFrame()
 
     df = pd.DataFrame(rows)

--- a/table/kroviniai.py
+++ b/table/kroviniai.py
@@ -5,11 +5,11 @@ from typing import List, Dict, Any
 
 def show_kroviniai_table(rows: List[Dict[str, Any]]) -> pd.DataFrame:
     """
-    Rodo krovinių lentelę su galimybe dinamiškai redaguoti įrašus.
-    Grąžina redaguotą DataFrame, kad būtų galima apdoroti pakeitimus.
+    Display cargo table with dynamic editing enabled.
+    Returns the edited DataFrame for processing.
     """
     if not rows:
-        st.info("ℹ️ Nėra krovinių įrašų.")
+        st.info("ℹ️ No cargo records.")
         return pd.DataFrame()
 
     df = pd.DataFrame(rows)

--- a/table/nustatymai.py
+++ b/table/nustatymai.py
@@ -4,12 +4,12 @@ from typing import List, Dict, Any
 
 def show_nustatymai_table(rows: List[Dict[str, Any]]) -> pd.DataFrame:
     """
-    Rodo lookup reikšmių lentelę su galimybe redaguoti.
-    rows turi būti sąrašas žodynų su laukais: id, kategorija, reiksme.
-    Grąžina redaguotą DataFrame.
+    Display lookup values table with editing enabled.
+    Rows should be dicts with: id, kategorija, reiksme.
+    Returns the edited DataFrame.
     """
     if not rows:
-        st.info("ℹ️ Nėra reikšmių.")
+        st.info("ℹ️ No values found.")
         return pd.DataFrame()
 
     df = pd.DataFrame(rows)

--- a/table/priekabos.py
+++ b/table/priekabos.py
@@ -4,7 +4,7 @@ from typing import List, Dict, Any
 
 def show_priekabos_table(rows: List[Dict[str, Any]]) -> pd.DataFrame:
     if not rows:
-        st.info("ℹ️ Nėra priekabų.")
+        st.info("ℹ️ No trailers available.")
         return pd.DataFrame()
 
     df = pd.DataFrame(rows)

--- a/table/vairuotojai.py
+++ b/table/vairuotojai.py
@@ -4,11 +4,11 @@ from typing import List, Dict, Any
 
 def show_vairuotojai_table(rows: List[Dict[str, Any]]) -> pd.DataFrame:
     """
-    Rodo vairuotojų lentelę su galimybe redaguoti įrašus.
-    Grąžina redaguotą DataFrame, kad būtų galima apdoroti pakeitimus.
+    Display drivers table with edit options.
+    Returns the edited DataFrame for processing.
     """
     if not rows:
-        st.info("ℹ️ Nėra vairuotojų įrašų.")
+        st.info("ℹ️ No driver records.")
         return pd.DataFrame()
 
     df = pd.DataFrame(rows)

--- a/table/vilkikai.py
+++ b/table/vilkikai.py
@@ -4,11 +4,11 @@ from typing import List, Dict, Any
 
 def show_vilkikai_table(rows: List[Dict[str, Any]]) -> pd.DataFrame:
     """
-    Rodo vilkikų lentelę su galimybe redaguoti.
-    Grąžina DataFrame su pakeitimais.
+    Display trucks table with editing enabled.
+    Returns the edited DataFrame.
     """
     if not rows:
-        st.info("ℹ️ Nėra vilkikų.")
+        st.info("ℹ️ No trucks available.")
         return pd.DataFrame()
 
     df = pd.DataFrame(rows)


### PR DESCRIPTION
## Summary
- translated all user-facing text to English across modules, forms and tables
- fixed form import names and added aliases for consistent usage
- updated main page to show English module names and corrected database init usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f70e42ff48324b850283f9b39092d